### PR TITLE
[ Feat ] Button 공통 컴포넌트 구현

### DIFF
--- a/app/components/button/Button.tsx
+++ b/app/components/button/Button.tsx
@@ -1,0 +1,16 @@
+import { ButtonHTMLAttributes } from "react";
+import { buttonStyle } from "./styles.css";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "text";
+}
+
+const Button = ({ variant = "primary", children, ...props }: ButtonProps) => {
+  return (
+    <button type="button" className={buttonStyle({ type: variant })} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/app/components/button/styles.css.ts
+++ b/app/components/button/styles.css.ts
@@ -21,6 +21,12 @@ export const buttonStyle = recipe({
     cursor: "pointer",
 
     transition: "ease-in-out 0.2s",
+
+    ":disabled": {
+      opacity: "0.64",
+
+      pointerEvents: "none",
+    },
   },
 
   variants: {
@@ -31,12 +37,6 @@ export const buttonStyle = recipe({
 
         "&:hover": {
           backgroundColor: colors.blue_200,
-        },
-
-        "&:disabled": {
-          opacity: "0.64",
-
-          pointerEvents: "none",
         },
       },
       secondary: {
@@ -49,12 +49,6 @@ export const buttonStyle = recipe({
         "&:hover": {
           backgroundColor: colors.gray_200,
         },
-
-        "&:disabled": {
-          opacity: "0.64",
-
-          pointerEvents: "none",
-        },
       },
       text: {
         border: "none",
@@ -65,12 +59,6 @@ export const buttonStyle = recipe({
 
         "&:hover": {
           color: colors.blue_100,
-        },
-
-        "&:disabled": {
-          opacity: "0.64",
-
-          pointerEvents: "none",
         },
       },
     },

--- a/app/components/button/styles.css.ts
+++ b/app/components/button/styles.css.ts
@@ -3,16 +3,22 @@ import { colors } from "~/styles/colors";
 
 export const buttonStyle = recipe({
   base: {
-    width: "100%",
-
     padding: "1.2rem 2rem",
 
+    justifyContent: "center",
+    alignItems: "center",
+
+    border: "none",
     borderRadius: "12px",
 
-    fontSize: "1.6rem",
+    fontSize: "16px",
     fontStyle: "normal",
     fontWeight: "500",
     lineHeight: "24px",
+
+    whiteSpace: "nowrap",
+
+    cursor: "pointer",
   },
 
   variants: {
@@ -30,6 +36,8 @@ export const buttonStyle = recipe({
       },
       text: {
         border: "none",
+
+        backgroundColor: colors.white,
 
         fontWeight: "400",
       },

--- a/app/components/button/styles.css.ts
+++ b/app/components/button/styles.css.ts
@@ -1,0 +1,41 @@
+import { recipe } from "@vanilla-extract/recipes";
+import { colors } from "~/styles/colors";
+
+export const buttonStyle = recipe({
+  base: {
+    width: "100%",
+
+    padding: "1.2rem 2rem",
+
+    borderRadius: "12px",
+
+    fontSize: "1.6rem",
+    fontStyle: "normal",
+    fontWeight: "500",
+    lineHeight: "24px",
+  },
+
+  variants: {
+    type: {
+      primary: {
+        backgroundColor: colors.primary_blue,
+        color: colors.white,
+      },
+      secondary: {
+        border: "1px solid rgba(105, 106, 117, 0.30)",
+        borderRadius: "6px",
+
+        backgroundColor: colors.white,
+        color: colors.gray_500,
+      },
+      text: {
+        border: "none",
+
+        fontWeight: "400",
+      },
+    },
+  },
+  defaultVariants: {
+    type: "primary",
+  },
+});

--- a/app/components/button/styles.css.ts
+++ b/app/components/button/styles.css.ts
@@ -19,13 +19,25 @@ export const buttonStyle = recipe({
     whiteSpace: "nowrap",
 
     cursor: "pointer",
+
+    transition: "ease-in-out 0.2s",
   },
 
   variants: {
     type: {
       primary: {
-        backgroundColor: colors.primary_blue,
+        backgroundColor: colors.blue_100,
         color: colors.white,
+
+        "&:hover": {
+          backgroundColor: colors.blue_200,
+        },
+
+        "&:disabled": {
+          opacity: "0.64",
+
+          pointerEvents: "none",
+        },
       },
       secondary: {
         border: "1px solid rgba(105, 106, 117, 0.30)",
@@ -33,6 +45,16 @@ export const buttonStyle = recipe({
 
         backgroundColor: colors.white,
         color: colors.gray_500,
+
+        "&:hover": {
+          backgroundColor: colors.gray_200,
+        },
+
+        "&:disabled": {
+          opacity: "0.64",
+
+          pointerEvents: "none",
+        },
       },
       text: {
         border: "none",
@@ -40,6 +62,16 @@ export const buttonStyle = recipe({
         backgroundColor: colors.white,
 
         fontWeight: "400",
+
+        "&:hover": {
+          color: colors.blue_100,
+        },
+
+        "&:disabled": {
+          opacity: "0.64",
+
+          pointerEvents: "none",
+        },
       },
     },
   },

--- a/app/components/switch/styles.css.ts
+++ b/app/components/switch/styles.css.ts
@@ -22,7 +22,7 @@ export const backgroundStyle = recipe({
         background: colors.gray_200,
       },
       dark: {
-        background: colors.primary_blue,
+        background: colors.blue_100,
       },
     },
   },

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -9,6 +9,9 @@ export const colors = {
   gray_700: "#242535",
   gray_800: "#181A2A",
   gray_900: "#141624",
-  primary_blue: "#4B6BFB",
+
+  blue_100: "#4B6BFB",
+  blue_200: "#3A57E8",
+
   navy_bg: "#242535",
 };


### PR DESCRIPTION
## 📌 Related Issue
closed #4 

## 🚀 Description
3가지 variant에 따라 스타일을 지정해줬습니다.
```tsx
export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  variant?: "primary" | "secondary" | "text";
}
```
- size와 관련된 prop도 넘기려다가 아직 다양한 크기의 버튼이 필요하지 않아서 우선은 외부에서 width를 지정하고, 후에 prop으로 넘길 것 같습니다.
- `ButtonHTMLAttributes<HTMLButtonElement>`를 상속받아서 기존 Button이 갖고 있는 이벤트나 prop을 사용할 수 있도록 구현했습니다.


### ✨ 알게된 것
Switch 컴포넌트를 구현할 때와 마찬가지로 vanilla extract의 recipe를 활용했는데, 이때 공통적인 스타일 속성에 해당하는 base의 disabled일 때 스타일을 지정하려면
```css
    ":disabled": {
      opacity: "0.64",

      pointerEvents: "none",
    },
```
위와 같이 `&` 선택자 없이 지정해야함을 알게 되었습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/4ec6e325-2f1f-438b-88b5-d395d7dc3d9b

